### PR TITLE
Fix handling of missing playlist URL

### DIFF
--- a/playlist_downloader.py
+++ b/playlist_downloader.py
@@ -30,9 +30,10 @@ downloadQueue = [] #songs to be downloaded
 
 try:
     playlist_url = sys.argv[1]
-
 except IndexError:
     print("Error - no playlist link found")
+    print("Usage: python playlist_downloader.py <playlist_url>")
+    sys.exit(1)
 
 print("Getting all songs from playlist...")
 songs, folder_name = getTracks(playlist_url, sp)


### PR DESCRIPTION
## Summary
- exit early if `playlist_downloader.py` is run without an argument

## Testing
- `python -m py_compile playlist_downloader.py downloader_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_6840d732eba483259c05d8e1909c0a39