### PR TITLE
fix: handle query parameters in playlist URL

### DIFF
--- a/downloader_functions.py
+++ b/downloader_functions.py
@@ -16,10 +16,12 @@ def getTracks(playlist_url, sp):
 
         playlist_user = playlist_url.split('user/')[1].split('/')[0]
         playlist_id = playlist_url.split('playlist/')[1]
+        playlist_id = playlist_id.split('?', 1)[0]
 
     else:
         playlist_user = playlist_url.split(':')[0]
         playlist_id = playlist_url.split(':')[-1]
+        playlist_id = playlist_id.split('?', 1)[0]
     
     playlist = sp.user_playlist(playlist_user, playlist_id)
 


### PR DESCRIPTION
## Summary
- handle query parameters that may be present in playlist URLs

## Testing
- `python -m py_compile downloader_functions.py playlist_downloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6840e249d12c8325a331efe72081990c