### PR TITLE
Improve album art cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The YouTube search logic now scores results using fuzzy title matching and
 duration similarity which helps select the official or most accurate audio
 track for each song.
 
+Album artwork is now removed as soon as all tracks from that album have been
+processed rather than waiting until the end of the run.
+
 ## Usage
 
 Run `playlist_downloader.py` with the playlist URL:

--- a/playlist_downloader.py
+++ b/playlist_downloader.py
@@ -28,6 +28,8 @@ shelveFile.close()
 #set variables
 threadList = []  # stores all threads
 downloadQueue = []  # songs to be downloaded
+album_counts = {}
+album_lock = threading.Lock()
 
 parser = argparse.ArgumentParser(description="Download songs from a Spotify playlist")
 parser.add_argument("playlist_url", help="Spotify playlist URL or URI")
@@ -69,6 +71,9 @@ for song in songs:
     else:
         downloadQueue.append(song)
 
+for song in downloadQueue:
+    album_counts[song.album] = album_counts.get(song.album, 0) + 1
+
 # Progress bar for all songs (downloaded + to download)
 progress_bar = tqdm(total=len(songs), desc="Processing Songs", unit="song", 
                    bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]')
@@ -105,6 +110,17 @@ def thread_download(song):
             progress_bar.start_t = progress_bar._time()
     
     downloadSong(song, quiet=True)
+
+    # Clean up album art when no longer needed
+    with album_lock:
+        album_counts[song.album] -= 1
+        if album_counts[song.album] == 0:
+            art_path = os.path.join(folder_name, song.album + '.jpg')
+            if os.path.exists(art_path):
+                try:
+                    os.remove(art_path)
+                except FileNotFoundError:
+                    pass
     
     with downloading_lock:
         currently_downloading.remove(song.name)


### PR DESCRIPTION
## Summary
- clean up album art when the last track from an album finishes
- track album counts and remove art per-album
- document early cleanup of album art

## Testing
- `bash download_playlist.sh` *(fails: interrupted)*
- `python playlist_downloader.py https://open.spotify.com/playlist/6kVbhdK2ymPGUUXzXfZXvh?si=6cb919d48ea640bd --limit 10`

------
https://chatgpt.com/codex/tasks/task_e_6841032d813883258134e6e7cb99b1a9