### PR TITLE
Add HiFi success tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Agents.md
+__pycache__/
+spotify_data*
+run.log
+.cache/

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 Downloads all songs in a Spotify playlist from YouTube.
 
 # Required Modules
-spotipy, sys, os, urllib, requests, threading, subprocess, eyed3, youtube_dl, pafy, bs4, pytube, tqdm
+spotipy, sys, os, urllib, requests, threading, subprocess, eyed3, mutagen, youtube_dl, pafy, bs4, pytube, tqdm
 
 ## Improvements
 The YouTube search logic now scores results using fuzzy title matching and
 duration similarity which helps select the official or most accurate audio
 track for each song.
+
+### High Fidelity Downloads
+The downloader first attempts to retrieve audio as lossless FLAC from
+SoundCloud using `yt-dlp`. If that fails, it falls back to the previous FLAC
+method that downloads from YouTube, and finally to the original mp3 workflow.
+Album art and metadata continue to be embedded in the resulting files.

--- a/download_playlist.bat
+++ b/download_playlist.bat
@@ -4,7 +4,7 @@ if not exist "%USERPROFILE%\Desktop\Music" mkdir "%USERPROFILE%\Desktop\Music"
 
 :: Install required dependencies
 echo Installing dependencies...
-pip install spotipy yt-dlp pafy beautifulsoup4 pytube eyed3 requests >nul 2>&1
+pip install spotipy yt-dlp pafy beautifulsoup4 pytube eyed3 requests mutagen >nul 2>&1
 
 :: Check if ffmpeg is installed, install if not found
 ffmpeg -version >nul 2>&1

--- a/download_playlist.sh
+++ b/download_playlist.sh
@@ -5,7 +5,7 @@ export PAFY_BACKEND=internal
 
 # Install required dependencies
 echo "Installing dependencies..."
-pip install spotipy yt-dlp pafy beautifulsoup4 pytube eyed3 requests tqdm > /dev/null 2>&1
+pip install spotipy yt-dlp pafy beautifulsoup4 pytube eyed3 requests tqdm mutagen > /dev/null 2>&1
 
 # Check if ffmpeg is installed, install if not found
 if ! command -v ffmpeg &> /dev/null; then


### PR DESCRIPTION
## Summary
- track how often the high fidelity method succeeds in `playlist_downloader`
- return success state from download helpers
- normalize file endings

## Testing
- `python -m py_compile playlist_downloader.py downloader_functions.py`
- `bash -n download_playlist.sh`
- `SONG_LIMIT=30 bash download_playlist.sh` *(fails: missing Spotify credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6840ffc69ae08325b12f18344030fd9a