### PR TITLE
Add browser-based Spotify auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ To download only the first N songs, provide the `--limit` option:
 ```bash
 python playlist_downloader.py <playlist_url> --limit N
 ```
+
+If you prefer to authenticate through your web browser instead of providing a
+client ID and secret, add the `--user-auth` flag. A browser window will open so
+you can log into Spotify:
+
+```bash
+python playlist_downloader.py <playlist_url> --user-auth
+```

--- a/download_playlist.bat
+++ b/download_playlist.bat
@@ -23,5 +23,5 @@ cd "%USERPROFILE%\Desktop\Music"
 set playlistlink=https://open.spotify.com/playlist/6kVbhdK2ymPGUUXzXfZXvh?si=6cb919d48ea640bd
 
 echo Downloading Playlist...
-python "%~dp0playlist_downloader.py" %playlistlink% --user-auth
+python "%~dp0playlist_downloader.py" %playlistlink%
 PAUSE

--- a/download_playlist.bat
+++ b/download_playlist.bat
@@ -23,5 +23,5 @@ cd "%USERPROFILE%\Desktop\Music"
 set playlistlink=https://open.spotify.com/playlist/6kVbhdK2ymPGUUXzXfZXvh?si=6cb919d48ea640bd
 
 echo Downloading Playlist...
-python "%~dp0playlist_downloader.py" %playlistlink%
+python "%~dp0playlist_downloader.py" %playlistlink% --user-auth
 PAUSE


### PR DESCRIPTION
## Summary
- add command line argument `--user-auth` to authenticate via browser
- implement Spotify OAuth login when using the new flag
- document the new option in README

## Testing
- `pip install spotipy yt-dlp pafy beautifulsoup4 pytube eyed3 requests tqdm`
- `python playlist_downloader.py https://open.spotify.com/playlist/6kVbhdK2ymPGUUXzXfZXvh?si=6cb919d48ea640bd --limit 2 --user-auth` *(fails: waits for browser login)*
- `python playlist_downloader.py https://open.spotify.com/playlist/6kVbhdK2ymPGUUXzXfZXvh?si=6cb919d48ea640bd --limit 1`

------
https://chatgpt.com/codex/tasks/task_e_68411562ab888325b23a95f37fe1d01a