### PR TITLE
Organize downloads by artist and album

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,6 @@ you can log into Spotify:
 ```bash
 python playlist_downloader.py <playlist_url> --user-auth
 ```
+
+## Folder Structure
+Downloaded songs are saved under `Playlist Name/Artist/(YEAR) Album` and include the track number in the filename (e.g. `1 - Track Title.mp3`).

--- a/debug_downloader.py
+++ b/debug_downloader.py
@@ -4,7 +4,9 @@ Debug version of the playlist downloader that shows which providers are being tr
 This patches the downloader functions to add logging.
 """
 
-import spotipy, os, urllib, pafy, shelve, threading, sys, argparse
+import spotipy, os, urllib, shelve, threading, sys, argparse
+os.environ.setdefault('PAFY_BACKEND', 'internal')
+import pafy
 from tqdm import tqdm
 from spotipy.oauth2 import SpotifyClientCredentials
 from downloader_functions import *
@@ -192,13 +194,14 @@ songs, folder_name = getTracks(playlist_url, sp, limit=limit)
 os.makedirs(folder_name, exist_ok=True)
 
 print("Checking already downloaded songs...")
-#get URIs of downloaded songs
+# get URIs of downloaded songs
 URIs = []
 playlistFolderURIs = []
-for file in os.listdir(folder_name):
-    file_path = os.path.join(folder_name, file)
-    if os.path.isfile(file_path):
-        playlistFolderURIs.append(getUri(file_path))
+for root, _, files in os.walk(folder_name):
+    for file in files:
+        file_path = os.path.join(root, file)
+        if os.path.isfile(file_path):
+            playlistFolderURIs.append(getUri(file_path))
 
 #Don't download dupe songs from other folders
 URIs.extend(playlistFolderURIs)
@@ -208,10 +211,11 @@ for folder in os.listdir():
         continue
     if not os.path.isdir(folder):
         continue
-    for file in os.listdir(folder):
-        file_path = os.path.join(folder, file)
-        if os.path.isfile(file_path):
-            URIs.append(getUri(file_path))
+    for root, _, files in os.walk(folder):
+        for file in files:
+            file_path = os.path.join(root, file)
+            if os.path.isfile(file_path):
+                URIs.append(getUri(file_path))
 
 for song in songs:
     if song.uri in URIs:

--- a/playlist_downloader.py
+++ b/playlist_downloader.py
@@ -1,5 +1,6 @@
 import spotipy
 import os
+os.environ.setdefault('PAFY_BACKEND', 'internal')
 import urllib
 import pafy
 import shelve
@@ -136,13 +137,14 @@ songs, folder_name = getTracks(playlist_url, sp, limit=limit)
 os.makedirs(folder_name, exist_ok=True)
 
 print("Checking already downloaded songs...")
-#get URIs of downloaded songs
+# get URIs of downloaded songs
 URIs = []
 playlistFolderURIs = []
-for file in os.listdir(folder_name):
-    file_path = os.path.join(folder_name, file)
-    if os.path.isfile(file_path):
-        playlistFolderURIs.append(getUri(file_path))
+for root, _, files in os.walk(folder_name):
+    for file in files:
+        file_path = os.path.join(root, file)
+        if os.path.isfile(file_path):
+            playlistFolderURIs.append(getUri(file_path))
 
 
 #Don't download dupe songs from other folders
@@ -153,10 +155,11 @@ for folder in os.listdir():
         continue
     if not os.path.isdir(folder):
         continue
-    for file in os.listdir(folder):
-        file_path = os.path.join(folder, file)
-        if os.path.isfile(file_path):
-            URIs.append(getUri(file_path))
+    for root, _, files in os.walk(folder):
+        for file in files:
+            file_path = os.path.join(root, file)
+            if os.path.isfile(file_path):
+                URIs.append(getUri(file_path))
 
 for song in songs:
     if song.uri in URIs:


### PR DESCRIPTION
## Summary
- place downloaded tracks under Artist/(YEAR) Album folder hierarchy
- prefix track number in downloaded filename
- recursively scan folders when checking for downloaded files
- configure PAFY_BACKEND before importing pafy
- strip whitespace when sanitizing names
- document new folder structure in README

## Testing
- `python playlist_downloader.py https://open.spotify.com/playlist/6kVbhdK2ymPGUUXzXfZXvh?si=05089fa4d7f1409b --limit 10`

------
https://chatgpt.com/codex/tasks/task_e_684246d1081c83258c015aa5de9a4d7f